### PR TITLE
Remove filelock when reading in column depth spline

### DIFF
--- a/taurunner/track/utils/spline_column_depth.py
+++ b/taurunner/track/utils/spline_column_depth.py
@@ -120,9 +120,8 @@ def set_spline(track, body, npad=5):
     if track.desc=='chord':
         x2X_fname, spline_exists = spline_fname(hash_s)
         if spline_exists:
-            with FileLock(x2X_fname):
-                with open(x2X_fname, 'rb') as pkl_file:
-                    x2X_spline =  pkl.load(pkl_file)
+            with open(x2X_fname, 'rb') as pkl_file:
+                x2X_spline =  pkl.load(pkl_file)
         else:
             from taurunner.track import chord
             if track.depth==0:


### PR DESCRIPTION
I believe the use of the FileLock when reading in the spline is unnecessary. I also found that it slows down the speed of TauRunner significantly if running multiple instances of TauRunner in parallel.