### PR TITLE
fix hash to respect Linux max filename size

### DIFF
--- a/taurunner/track/utils/spline_column_depth.py
+++ b/taurunner/track/utils/spline_column_depth.py
@@ -11,6 +11,8 @@ else:
 import os
 import pickle as pkl
 
+import hashlib
+
 from taurunner.utils import FileLock
 import taurunner as tr
 
@@ -91,7 +93,7 @@ def get_hash(track, body):
         s += str(bd)
         s += str(body.get_density(bd))
     s = s.replace('.', 'd').replace('+', 'p')
-    return s
+    return hashlib.md5(s.encode('utf-8')).hexdigest()
 
 def spline_fname(hash_s):    
     x2X_fname = f'{SPLINE_PATH}/{hash_s}_x_to_X.pkl'


### PR DESCRIPTION
Current implementation of column depth spline lock file results in very long filenames that often run over the length of the max filename size allowed by Linux. Fix by making the lock filename a real hash.