### PR TITLE
Fix PROPOSAL interpolation tables path being silently ignored

### DIFF
--- a/TauRunner.jl/src/ChargedLeptonPropagation/ConfigGeneration.jl
+++ b/TauRunner.jl/src/ChargedLeptonPropagation/ConfigGeneration.jl
@@ -147,8 +147,7 @@ function generate_sphere_config(body::AbstractSphericalBody; cuts=default_cuts()
 
     config = Dict(
         "global" => Dict(
-            "cuts" => cuts,
-            "tables_path" => get_proposal_tables_path()
+            "cuts" => cuts
         ),
         "sectors" => sectors
     )
@@ -169,8 +168,7 @@ Generate a simple uniform sphere configuration.
 function generate_uniform_sphere_config(radius_cm::Real, medium::String; cuts=default_cuts())
     config = Dict(
         "global" => Dict(
-            "cuts" => cuts,
-            "tables_path" => get_proposal_tables_path()
+            "cuts" => cuts
         ),
         "sectors" => [
             Dict(
@@ -204,8 +202,7 @@ exactly on a sector boundary due to floating-point arithmetic.
 function generate_slab_layer_config(density_gcm3::Real, medium_name::String; cuts=default_cuts())
     config = Dict(
         "global" => Dict(
-            "cuts" => cuts,
-            "tables_path" => get_proposal_tables_path()
+            "cuts" => cuts
         ),
         "sectors" => [
             Dict(
@@ -244,6 +241,11 @@ end
 Write config to a temporary file and return the path.
 """
 function create_temp_config(config::Dict)
+    # PROPOSAL reads its interpolation-table directory from a process-global
+    # (InterpolationSettings::TABLES_PATH), NOT from the JSON config. Push the
+    # resolved path in here so it takes effect before the propagator is built.
+    PROPOSAL.set_tables_path(get_proposal_tables_path())
+
     filepath = tempname() * ".json"
     write_config(config, filepath)
     return filepath


### PR DESCRIPTION
## Summary

`ChargedLeptonPropagation` generates PROPOSAL JSON configs with a `tables_path` key under `config["global"]`, populated from `get_proposal_tables_path()` (which honors the `PROPOSAL_TABLES_PATH` environment variable). **PROPOSAL never reads that key.**

PROPOSAL stores its interpolation-table directory in a process-global C++ static, `InterpolationSettings::TABLES_PATH`, whose only mutator is `PROPOSAL.set_tables_path(...)`. Because the JSON `tables_path` key is discarded, the whole `PROPOSAL_TABLES_PATH` → `get_proposal_tables_path()` → JSON chain has no effect: interpolation tables always land at PROPOSAL's compiled-in default (`/tmp`), regardless of the env var.

## Fix

- Call `PROPOSAL.set_tables_path(get_proposal_tables_path())` in `create_temp_config` — the single chokepoint run immediately before every `create_propagator_*` call, so the global is correct at propagator-creation time for both `SphericalBodyPropagator` and `SlabPropagator`.
- Remove the dead `tables_path` key from all three config generators (`generate_sphere_config`, `generate_uniform_sphere_config`, `generate_slab_layer_config`) — leaving it in falsely implies PROPOSAL consumes it.

`PROPOSAL_TABLES_PATH` is now a working knob again.

## Test plan

- [x] `Pkg.test()` — full suite passes (449/449).
- [x] Verified incidentally: with no `PROPOSAL_TABLES_PATH` set, the test run wrote `.dat` tables into the bundled `data/proposal_tables/` default rather than `/tmp`, confirming the path now takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)